### PR TITLE
Prevent Index#commit from modifying parents argument.

### DIFF
--- a/lib/rjgit_adapter/git_layer_rjgit.rb
+++ b/lib/rjgit_adapter/git_layer_rjgit.rb
@@ -245,7 +245,7 @@ module Gollum
       def commit(message, parents = nil, actor = nil, last_tree = nil, ref = "refs/heads/master")
         ref = Gollum::Git.canonicalize(ref)
         actor = actor ? actor.actor : RJGit::Actor.new("Gollum", "gollum@wiki")
-        parents.map!{|parent| parent.commit} if parents
+        parents = parents.map{|parent| parent.commit} if parents
         commit_data = @index.commit(message, actor, parents, ref)
         return false if !commit_data
         commit_data[2]


### PR DESCRIPTION
In the same way that `rugged_adapter` did, the `Gollum::Git::Index#commit` method also modified the `parents` argument, replacing the objects in it with `RJGit::Commit` objects.

That seems weird to me, so I wrote this one-line pull request.