### PR TITLE
[WIP] Advanced grep

### DIFF
--- a/lib/jgit_tree_apply.rb
+++ b/lib/jgit_tree_apply.rb
@@ -1,5 +1,0 @@
-import 'org.eclipse.jgit.ApplyCommand'
-
-class TreeApplyCommand < ApplyCommand
-
-end

--- a/lib/jgit_tree_apply.rb
+++ b/lib/jgit_tree_apply.rb
@@ -1,0 +1,5 @@
+import 'org.eclipse.jgit.ApplyCommand'
+
+class TreeApplyCommand < ApplyCommand
+
+end

--- a/lib/rjgit_adapter/git_layer_rjgit.rb
+++ b/lib/rjgit_adapter/git_layer_rjgit.rb
@@ -160,11 +160,14 @@ module Gollum
           blobs << RJGit::Blob.new(@git.jrepo, item[:mode], item[:path], walk.lookup_blob(ObjectId.from_string(item[:id]))) if item[:type] == 'blob'
         end
         result = []
+        regex_query = query.scan(/"([^"]+)"|(\S+)/).flatten.compact.map {|word| Regexp.escape(word)}
+        regex_query = "(?:#{regex_query.join('|')})"
         blobs.each do |blob|
           next if blob.binary?
-          count = blob.data.scan(/#{query}/i).length
-          result << {:name => blob.path, :count => count} if count > 0
+          in_blob = blob.data.scan(/^(.*#{regex_query}.*)$/i).flatten
+          result << {:name => blob.path, :result => in_blob, :line_count => in_blob.length} if in_blob.length > 0
         end
+        puts result.inspect
         result
       end
       


### PR DESCRIPTION
An experiment. Not sure if all of this should be default, or whether we should allow different kinds of searches.

* Make grep verbose (return the whole line on which each hit was found in the results)
* Allow looking for multiple words
  *  query string will be split up, e.g. searching for `'foo bar'` will yield results for both `'foo'` and `'bar'`
  *  however, double-quotes will be respected, so searching for `'"foo bar"'` will only yield results for `'foo bar'`